### PR TITLE
add files list to package.json

### DIFF
--- a/package.json
+++ b/package.json
@@ -15,6 +15,9 @@
     "email": "tom@tbremer.com"
   },
   "license": "MIT",
+  "files": [
+    "dist"  
+  ],
   "repository": {
     "type": "git",
     "url": "git+https://github.com/tbremer/babel-plugin-jsx-to-object.git"


### PR DESCRIPTION
This prevents publishing `src/` and `test/`. If the `files` key or a `.npmignore` file are in the project then npm's `publish` will not publish all files in directory.

In the future after this first version is published, you can access https://npmcdn.com/babel-plugin-jsx-to-object@0.1.0/ (that last slash is important!) to view the files being published as a sanity check.
